### PR TITLE
Use of a token file, and addition of report feature

### DIFF
--- a/src/main/groovy/com/ibm/appscan/gradle/AppScanSettingsExtension.groovy
+++ b/src/main/groovy/com/ibm/appscan/gradle/AppScanSettingsExtension.groovy
@@ -14,6 +14,7 @@ public class AppScanSettingsExtension {
 	String scriptdir
 	String installdir = "C:/Program Files (x86)/IBM/AppScanSource"
 	String logdir
+	String tokenfile
 	String username = ""
 	String password = ""
 	String server = "localhost"
@@ -26,5 +27,7 @@ public class AppScanSettingsExtension {
 		appdir = project.getRootProject().getRootDir().getAbsolutePath()
 		logdir = new File(project.getRootProject().getRootDir(), "appscan").getAbsolutePath()
 		scriptdir = new File(project.getRootProject().getRootDir(), "appscan").getAbsolutePath()
-	}	
+		def usertoken = new File(System.getProperty("user.home"), ".ounce/ouncecli.token")
+		tokenfile = usertoken.exists() ? usertoken.getAbsolutePath() : "C:/ProgramData/IBM/AppScanSource/config/ounceautod.token"
+	}
 }

--- a/src/main/groovy/com/ibm/appscan/gradle/AppScanSettingsExtension.groovy
+++ b/src/main/groovy/com/ibm/appscan/gradle/AppScanSettingsExtension.groovy
@@ -20,6 +20,7 @@ public class AppScanSettingsExtension {
 	String server = "localhost"
 	String scanoptions = ""
 	String sourceexcludes = "test"
+	String reportoptions = ""
 
 	public AppScanSettingsExtension(Project project) {
 		projectname = project.name

--- a/src/main/groovy/com/ibm/appscan/gradle/ScriptCreator.groovy
+++ b/src/main/groovy/com/ibm/appscan/gradle/ScriptCreator.groovy
@@ -21,7 +21,10 @@ public class ScriptCreator extends AppScanTask {
 			cliscript.delete()
 				
 		//Create the new script
-		cliscript << ("login $m_project.appscansettings.server $m_project.appscansettings.username $m_project.appscansettings.password -acceptssl" + newline)
+		if(m_project.appscansettings.username != "" && m_project.appscansettings.password != "")
+			cliscript << ("login $m_project.appscansettings.server $m_project.appscansettings.username $m_project.appscansettings.password -acceptssl" + newline)
+		else
+			cliscript << ("login_file $m_project.appscansettings.server $m_project.appscansettings.tokenfile -acceptssl" + newline)
 		cliscript << ("oa " + applicationfile.getAbsolutePath() + newline)
 		cliscript << ("scan $m_project.appscansettings.scanoptions" + newline)
 		cliscript << ("exit")

--- a/src/main/groovy/com/ibm/appscan/gradle/ScriptCreator.groovy
+++ b/src/main/groovy/com/ibm/appscan/gradle/ScriptCreator.groovy
@@ -27,6 +27,8 @@ public class ScriptCreator extends AppScanTask {
 			cliscript << ("login_file $m_project.appscansettings.server $m_project.appscansettings.tokenfile -acceptssl" + newline)
 		cliscript << ("oa " + applicationfile.getAbsolutePath() + newline)
 		cliscript << ("scan $m_project.appscansettings.scanoptions" + newline)
+		if(m_project.appscansettings.reportoptions != "")
+			cliscript << ("report $m_project.appscansettings.reportoptions" + newline)
 		cliscript << ("exit")
 	}
 }


### PR DESCRIPTION
This fix allows the following:
- Login to the AppScan Enterprise Server using a token file
- Generates an AppScan Source report
    - Set options of `report` command to `reportoptions`