### PR TITLE
Setting source root

### DIFF
--- a/src/main/groovy/com/ibm/appscan/gradle/AppScanPlugin.groovy
+++ b/src/main/groovy/com/ibm/appscan/gradle/AppScanPlugin.groovy
@@ -17,7 +17,7 @@ class AppScanPlugin implements Plugin<Project> {
         	project.task('createProject',
 				description: "Generates an AppScan Source project for this Gradle project.",
 				type: com.ibm.appscan.gradle.tasks.AppScanCreateProject) {
-				classfiles = {project.plugins.hasPlugin("org.gradle.java") && project.hasProperty("compileJava") ? project.compileJava.outputs.files : project.files(project.projectDir)}
+				classfiles = {(project.plugins.hasPlugin("org.gradle.java") || project.plugins.hasPlugin("java")) && project.hasProperty("compileJava") ? project.compileJava.outputs.files : project.files(project.projectDir)}
 		}
 
 		project.task('createCLIScript',

--- a/src/main/groovy/com/ibm/appscan/gradle/handlers/CreateProjectHandler.groovy
+++ b/src/main/groovy/com/ibm/appscan/gradle/handlers/CreateProjectHandler.groovy
@@ -50,7 +50,7 @@ public class CreateProjectHandler extends AppScanHandler{
 						}
 					}
 				}
-				if(m_project.plugins.hasPlugin("org.gradle.war")) {
+				if(m_project.plugins.hasPlugin("org.gradle.war")|| m_project.plugins.hasPlugin("war")) {
 					ounceWeb (webContextRoot: m_project.webAppDir.getAbsolutePath())
 				}
 			}

--- a/src/main/groovy/com/ibm/appscan/gradle/handlers/CreateProjectHandler.groovy
+++ b/src/main/groovy/com/ibm/appscan/gradle/handlers/CreateProjectHandler.groovy
@@ -45,7 +45,9 @@ public class CreateProjectHandler extends AppScanHandler{
 			appDir: m_appdir) {
 				for(SourceSet sourceSet : m_project.sourceSets) {
 					if(!m_exclusions.contains(sourceSet.getName())) {
-						ounceSourceRoot(dir: sourceSet.output.classesDir)
+						for(File file : sourceSet.java.getSrcDirs()) {
+							ounceSourceRoot(dir: m_project.relativePath(file))
+						}
 					}
 				}
 				if(m_project.plugins.hasPlugin("org.gradle.war")) {

--- a/src/main/groovy/com/ibm/appscan/gradle/tasks/AppScanCreateProject.groovy
+++ b/src/main/groovy/com/ibm/appscan/gradle/tasks/AppScanCreateProject.groovy
@@ -24,7 +24,7 @@ class AppScanCreateProject extends DefaultTask {
 	
 	@TaskAction
 	def createAppScanProject() {
-		if(project.plugins.hasPlugin("org.gradle.java")) {
+		if(project.plugins.hasPlugin("java") || project.plugins.hasPlugin("org.gradle.java")) {
 			configureSettings()
 			try {
 				new CreateProjectHandler(project).run()


### PR DESCRIPTION
I was wondering why do we scan .class files instead of .java files? If we scan .java files, later on if we open .ozasmt file with AppScan we will be able to view the source code. But by scanning .class file we have to find the related .java files manually ourselves.