### PR TITLE
Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 build/**
 bin/**
 .settings/**
+.classpath
+.project
+

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'com.gradle.plugin-publish'
 apply plugin: 'groovy'
 
 group = 'com.ibm.security'
-version = '1.1.7'
+version = '1.1.8'
 
 dependencies {
     compile gradleApi()

--- a/src/main/groovy/com/ibm/appscan/gradle/AppScanConstants.groovy
+++ b/src/main/groovy/com/ibm/appscan/gradle/AppScanConstants.groovy
@@ -1,0 +1,8 @@
+package com.ibm.appscan.gradle;
+
+public interface AppScanConstants {
+
+	String INSTALL 			= "appscan.install"
+	String APP_DIR 			= "appscan.appdir"
+	String PROJECT_DIR 		= "appscan.projectdir"
+}

--- a/src/main/groovy/com/ibm/appscan/gradle/AppScanPlugin.groovy
+++ b/src/main/groovy/com/ibm/appscan/gradle/AppScanPlugin.groovy
@@ -29,7 +29,7 @@ class AppScanPlugin implements Plugin<Project> {
 		project.task('runScan',
 				description: "Executes a security scan of this project and all subprojects.",
 				type: com.ibm.appscan.gradle.tasks.AppScanRunScript,
-				dependsOn: ':createCLIScript') << {
+				dependsOn: ':createCLIScript') {
 		}
     }
 }

--- a/src/main/groovy/com/ibm/appscan/gradle/settings/AppScanSettingsExtension.groovy
+++ b/src/main/groovy/com/ibm/appscan/gradle/settings/AppScanSettingsExtension.groovy
@@ -2,7 +2,9 @@ package com.ibm.appscan.gradle.settings;
 
 import org.gradle.api.Project
 
-public class AppScanSettingsExtension {
+import com.ibm.appscan.gradle.AppScanConstants
+
+public class AppScanSettingsExtension implements AppScanConstants {
 
 	//Don't allow changing the script name since we need to delete the file for each run.
 	final String scriptname = "cliscript.txt"
@@ -11,6 +13,7 @@ public class AppScanSettingsExtension {
 	String projectname
 	String appname
 	String appdir
+	String projectdir
 	String scriptdir
 	String installdir
 	String configdir
@@ -33,7 +36,8 @@ public class AppScanSettingsExtension {
 	public AppScanSettingsExtension(Project project) {
 		projectname = project.name
 		appname = project.rootProject.name
-		appdir = project.rootDir.getAbsolutePath()
+		appdir = System.getProperty(APP_DIR) == null ? project.rootDir.getAbsolutePath() : System.getProperty(APP_DIR)
+		projectdir = System.getProperty(PROJECT_DIR)
 		logdir = new File(project.rootDir, "appscan").getAbsolutePath()
 		scriptdir = new File(project.rootDir, "appscan").getAbsolutePath()
 		setAppScanDirs()
@@ -44,15 +48,15 @@ public class AppScanSettingsExtension {
 	private void setAppScanDirs() {
 		String osName = System.getProperty("os.name").toLowerCase()
 		if(osName.contains("windows")) {
-			installdir = "C:/Program Files (x86)/IBM/AppScanSource"
+			installdir = System.getProperty(INSTALL) ?: "C:/Program Files (x86)/IBM/AppScanSource"
 			configdir = "C:/ProgramData/IBM/AppScanSource"	
 		}
 		else if(osName.contains("mac")) {
-			installdir = "/Applications/AppScanSource.app"
+			installdir = System.getProperty(INSTALL) ?: "/Applications/AppScanSource.app"
 			configdir = "/Users/Shared/AppScanSource"	
 		}
 		else {
-			installdir = "/opt/ibm/appscansource"
+			installdir = System.getProperty(INSTALL) ?: "/opt/ibm/appscansource"
 			configdir = "/var/opt/ibm/appscansource"	
 		}
 	}

--- a/src/main/groovy/com/ibm/appscan/gradle/tasks/AppScanCreateProject.groovy
+++ b/src/main/groovy/com/ibm/appscan/gradle/tasks/AppScanCreateProject.groovy
@@ -16,6 +16,7 @@ class AppScanCreateProject extends DefaultTask {
 	
 	String applicationDir
 	String applicationName
+	String projectDir
 	String projectName
 	String exclusions
 
@@ -35,6 +36,7 @@ class AppScanCreateProject extends DefaultTask {
 	}
 	
 	void configureSettings() {
+		project.appscansettings.projectdir = projectDir ?: project.appscansettings.projectdir		
 		project.appscansettings.projectname = projectName ?: project.name
 		project.appscansettings.appdir = applicationDir ?: project.appscansettings.appdir
 		project.appscansettings.appname = applicationName ?: project.appscansettings.appname


### PR DESCRIPTION
These updates address the following issues:
     - Allow specifying the directory to store the project file (.ppf) using the "projectdir" property.
     - Allow specifying the installdir, appdir, and projectdir options on the command line using java properties.  For example:
          -Dappscan.installdir=/some/dir
          -Dappscan.appdir=/some/dir
          -Dappscan.projectdir=/some/dir
     - Fixed a problem where duplicate project entries were added to the application on subsequent runs.
